### PR TITLE
Fix item numbering in the 'Getting Started' page

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -47,7 +47,7 @@ Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" deni
 
 You just validated the container images in your k8s cluster!
 
-### Step 4: Uninstall
+### Step 3: Uninstall
 ```bash
 helmfile destroy --skip-charts -f git::https://github.com/ratify-project/ratify.git@helmfile.yaml
 ```


### PR DESCRIPTION
This is a small change on the Getting Started page to fix the numbering of items. There are three steps mentioned in the page, but it jumps from step 2 to step 4. So "Step 4" was changed to "Step 3"